### PR TITLE
Deque.take_while/2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_build
 /cover
 /deps
+/bench/snapshots
 erl_crash.dump
 *.ez
 .DS_Store

--- a/bench/deque_bench.exs
+++ b/bench/deque_bench.exs
@@ -1,11 +1,28 @@
 defmodule DequeBench do
   use Benchfella
 
-  @data Enum.to_list(0..200)
-  @max_size 100
-
-  bench "deque" do
-    Enum.reduce(@data, Deque.new(@max_size), &Deque.append(&2, &1))
+  bench "Deque.new/1" do
+    gen_deque(200, 100)
     :ok
+  end
+
+  bench "Enum.take_while/2", [deque: gen_deque(400, 400)] do
+    seq = 300
+    deque
+      |> Enum.reverse
+      |> Enum.take_while(&(&1 > seq))
+      |> Enum.reverse
+      |> Enum.into(Deque.clear(deque))
+    :ok
+  end
+
+  bench "Deque.take_while/2", [deque: gen_deque(400, 400)] do
+    seq = 300
+    Deque.take_while(deque, &(&1 > seq))
+    :ok
+  end
+
+  defp gen_deque(n, max_size) do
+    Enum.reduce(0..n, Deque.new(max_size), &Deque.append(&2, &1))
   end
 end

--- a/bench/deque_bench.exs
+++ b/bench/deque_bench.exs
@@ -6,7 +6,17 @@ defmodule DequeBench do
     :ok
   end
 
-  bench "Enum.take_while/2", [deque: gen_deque(400, 400)] do
+  bench "Enum.take_while/2 (best)", [deque: gen_deque(400, 400)] do
+    seq = 400
+    deque
+      |> Enum.reverse
+      |> Enum.take_while(&(&1 > seq))
+      |> Enum.reverse
+      |> Enum.into(Deque.clear(deque))
+    :ok
+  end
+
+  bench "Enum.take_while/2 (average)", [deque: gen_deque(400, 400)] do
     seq = 300
     deque
       |> Enum.reverse
@@ -16,8 +26,31 @@ defmodule DequeBench do
     :ok
   end
 
-  bench "Deque.take_while/2", [deque: gen_deque(400, 400)] do
+  bench "Enum.take_while/2 (worst)", [deque: gen_deque(400, 400)] do
+    seq = 100
+    deque
+      |> Enum.reverse
+      |> Enum.take_while(&(&1 > seq))
+      |> Enum.reverse
+      |> Enum.into(Deque.clear(deque))
+    :ok
+  end
+
+  bench "Deque.take_while/2 (best)", [deque: gen_deque(400, 400)] do
+    seq = 400
+    Deque.take_while(deque, &(&1 > seq))
+    :ok
+  end
+
+
+  bench "Deque.take_while/2 (average)", [deque: gen_deque(400, 400)] do
     seq = 300
+    Deque.take_while(deque, &(&1 > seq))
+    :ok
+  end
+
+  bench "Deque.take_while/2 (worst)", [deque: gen_deque(400, 400)] do
+    seq = 100
     Deque.take_while(deque, &(&1 > seq))
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Deque.Mixfile do
   def project do
     [
       app: :deque,
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/deque_test.exs
+++ b/test/deque_test.exs
@@ -41,7 +41,19 @@ defmodule DequeTest do
   end
 
   test "collectable/inspect" do
-    deque = Enum.into([1, 2, 3, 4, 5, 6], Deque.new(5))
+    deque = Enum.into(1..6, Deque.new(5))
     assert inspect(deque) == "#Deque<[2, 3, 4, 5, 6]>"
+  end
+
+  test "take_while" do
+    deque = gen_take_while(498..500, 5, 498)
+    assert Enum.to_list(deque) == [499, 500]
+
+    deque = gen_take_while(400..500, 10, 492)
+    assert Enum.to_list(deque) == [493, 494, 495, 496, 497, 498, 499, 500]
+  end
+
+  defp gen_take_while(range, max_size, max_value) do
+    range |> Enum.into(Deque.new(max_size)) |> Deque.take_while(&(&1 > max_value))
   end
 end


### PR DESCRIPTION
At Discord we use this library to keep message buffers that are in order (using append) and every 30-60sec prune the seen values. Currently we do this by using the `Enum` module but that can be expensive since it effectively has to loop over nearly everything as it does not understand the internals. 

Writing a function that knows the internals can allow short circuiting and very big performance gains.

```
## DequeBench (2500 items)
benchmark name      iterations   average time
Deque.take_while/2      100000   11.35 µs/op
Enum.take_while/2        10000   172.67 µs/op

## DequeBench (400 items)
benchmark name      iterations   average time
Deque.take_while/2      500000   4.74 µs/op
Enum.take_while/2        50000   36.30 µs/op
```