### PR TITLE
Implement slice/1 function which required by Enumerable protocol

### DIFF
--- a/lib/deque.ex
+++ b/lib/deque.ex
@@ -145,6 +145,10 @@ defmodule Deque do
     def count(%Deque{size: size}) do
       {:ok, size}
     end
+
+    def slice(%Deque{}) do
+      {:error, __MODULE__}
+    end
   end
 
   defimpl Collectable do


### PR DESCRIPTION
Remove annoying warning.