### PR TITLE
Upgrade benchfella dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Deque.Mixfile do
 
   defp deps do
     [
-      {:benchfella, "~> 0.3.0", only: :dev}
+      {:benchfella, "~> 0.3.5", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"benchfella": {:hex, :benchfella, "0.3.4", "41d2c017b361ece5225b5ba2e3b30ae53578c57c6ebc434417b4f1c2c94cf4f3", [:mix], []}}
+%{
+  "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
0.3.0 & 0.3.4 both use deprepcated functionality causing annoying
warnings. Specifically String.strip/1, String.rstrip/1, and
Float.to_string/2.

Upgrading versions cleans up warnings.